### PR TITLE
Changed InteractAreas to be attached to a belt

### DIFF
--- a/Scripts/InteractArea.gd
+++ b/Scripts/InteractArea.gd
@@ -1,9 +1,12 @@
 extends Area2D
 
+var belt: Node = null
+
 func _on_InteractArea_body_entered(body):
 	if body.is_in_group("robots"):
-		body.set_in_interact(true)
+		print("belt: "+str(belt))
+		body.in_interact.append(self)
 
 func _on_InteractArea_body_exited(body):
 	if body.is_in_group("robots"):
-		body.set_in_interact(false)
+		body.in_interact.erase(self)

--- a/Scripts/Main.gd
+++ b/Scripts/Main.gd
@@ -112,13 +112,6 @@ func _unhandled_input(event):
 #				_Navigation.get_node("NavigationPolygonInstance").navpoly = _Navigation.static_poly
 				pass
 
-	if event.is_action_pressed("ui_down"):
-		#to simply generate a package (carried by the robot) with a simple key press for testing purposes
-		_Package = PackageScene.instance()
-		_Robot.add_package(_Package)
-		_Package.set_processes([[0,3],[1,7]])
-
-
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
 	

--- a/Scripts/Robot.gd
+++ b/Scripts/Robot.gd
@@ -23,7 +23,7 @@ export var battery_charge_rate : float = 0.8
 var current_battery : float = 10.0
 
 var in_station: bool setget set_in_station
-var in_interact: bool setget set_in_interact
+var in_interact: Array = []
 
 onready var raycast : RayCast2D = $RayCast2D
 onready var _Progress = $Sprite/TextureProgress
@@ -97,9 +97,6 @@ func set_in_station(state : bool):
 	else:
 		$AnimationPlayer.seek(0,true)
 		$AnimationPlayer.stop()
-
-func set_in_interact(state : bool):
-	in_interact = state
 			
 func update_battery_display():
 	_Progress.value = current_battery/max_battery*100
@@ -197,13 +194,14 @@ func pickup():
 # If there is no node colliding, if the node is not in the given group,
 # or if the robot is not in an interaction area, returns null.
 func find_target_belt(type: int)->Node:
-	if !in_interact:
+	if in_interact.size() == 0:
 		return null
 	
 	var target_object = raycast.get_collider()
 	if target_object and target_object.is_in_group("belts") and target_object.belt_type == type:
-		return target_object
-		print("found belt")
-	else:
-		return null
+		for interact_area in in_interact:
+			if interact_area.belt == target_object:
+				return target_object
+	# If a condition has't been met, return null
+	return null
 	

--- a/Scripts/TileManager.gd
+++ b/Scripts/TileManager.gd
@@ -50,20 +50,35 @@ func get_used_cells_by_group(group: Array)->Array:
 func get_connected_cells_by_ids(world: TileWorld, ids: Array)->Array:
 	var connected_cells = []
 	var cells = world.data.duplicate(true)
-	var cells_transform = Transform2D(0, world.offset)
 	
 	for i in range(world.size.x):
 		for j in range(world.size.y):
 			if cells[i][j] in ids:
 				# from world data coordinates to real coordinates
-				connected_cells.append( cells_transform.xform( fill_cells(cells, Vector2(i,j), world.size, ids)))
+				connected_cells.append( world.transform.xform( fill_cells(cells, Vector2(i,j), world.size, ids)))
 	return connected_cells
 
 # same as get_connected_cells_by_ids(), but using an array of tile names instead.
 func get_connected_cells_by_group(world: TileWorld, group: Array)->Array:
 	return get_connected_cells_by_ids(world, get_ids_from_group(group))
 
+# Cell groups are given in tilemap space
+func get_connected_cells_to_groups_by_ids(world: TileWorld, cell_groups: Array, ids: Array)->Array:
+	var cells: Array = world.data.duplicate(true)
+	var connected_groups = []
+	
+	for group in cell_groups:
+		for cell in group:
+			var cells_to_fill = fill_adjacent_cells(cells, world.transform.xform_inv(cell), world.size, ids)
+			for to_fill in cells_to_fill:
+				connected_groups.append(fill_cells(cells, to_fill, world.size, ids))
+	return connected_groups
 
+func get_connected_cells_to_groups_by_group(world: TileWorld, cell_groups: Array, group: Array)->Array:
+	return get_connected_cells_to_groups_by_ids(world, cell_groups, get_ids_from_group(group))
+
+
+# Pos is given in tilemap space
 func get_adjacent_cells_by_ids(pos: Vector2, ids: Array)->Array:
 	var adjacent_cells = []
 	for dir in DIRS_4:
@@ -85,7 +100,6 @@ func get_outline(world: TileWorld)->PoolVector2Array:
 
 # Given an array of cell position, returns an array of 2-values arrays.
 # This is used to transform a PoolVector2Array into a JSON-compatible structure
-# Note: not recommended for big arrays of Vector2
 func cells_to_arrays(cells: Array)->Array:
 	var new_array = []
 	for cell in cells:

--- a/Scripts/TileWorld.gd
+++ b/Scripts/TileWorld.gd
@@ -8,6 +8,7 @@ class_name TileWorld
 var data: Array setget set_data, get_data
 var offset: Vector2 setget set_offset, get_offset
 var size: Vector2 setget set_size, get_size
+var transform: Transform2D 
 
 func _init(tilemap: TileMap = null):
 	# If no tilemap has been given, skip initialization
@@ -16,9 +17,9 @@ func _init(tilemap: TileMap = null):
 		
 	var used_rect = tilemap.get_used_rect()
 	
-	offset = used_rect.position
-	size = used_rect.size
-	data = []
+	set_offset(used_rect.position)
+	set_size(used_rect.size)
+	set_data([])
 	
 	for i in range(used_rect.position.x, used_rect.end.x):
 		var col = []
@@ -35,6 +36,7 @@ func get_offset()->Vector2:
 	return offset
 func set_offset(new_offset: Vector2):
 	offset = new_offset
+	transform = Transform2D(0, new_offset)
 
 func get_size()->Vector2:
 	return size


### PR DESCRIPTION
Added a new functions in TileManager to get all the cell groups attached to another cell group, so it can help build the InteractAreas from belts. 
Creates one InteractArea for each polygon
Changed the way the robot checks for a belt, to also check if it's in an InteractArea attached to the belt.

Changed the ParkingAreas to use one instance per polygon instead of a single instance for all polygons - this is to mirror the behavior of InteractArea and help locate different areas on the client's side.